### PR TITLE
Uses medium_large preset URL to close #1

### DIFF
--- a/wp-content/plugins/letsdothis/letsdothis.php
+++ b/wp-content/plugins/letsdothis/letsdothis.php
@@ -56,7 +56,7 @@ function ldt_encode_post(&$post) {
     $selected_attachment_id = $post->custom_fields->photo[0];
     foreach ($post->attachments as $attachment) {
       if ($attachment->id == $selected_attachment_id) {
-        $post->image_url = $attachment->url;
+        $post->image_url = $attachment->images["medium_large"]->url;
       }
     }
   }


### PR DESCRIPTION
The custom Post `image_url` property was returning the raw uploaded image URL, which is why loading times were so weaksauce.

This PR resolves #1 by changing the Post `image_url` to use the URL of the WordPress `medium_large` preset within the relevant `attachments` object, aiming to strike a happy balance between 3x devices like the iPhone 6 Plus and more common 2x devices:

<img width="984" alt="screen shot 2016-05-19 at 2 51 47 pm" src="https://cloud.githubusercontent.com/assets/1236811/15410942/8130b562-1dd1-11e6-9bde-cdd3e653482d.png">
